### PR TITLE
Optionally query the tags endpoint

### DIFF
--- a/lib/Alien/Build/Plugin/Download/GitHub.pm
+++ b/lib/Alien/Build/Plugin/Download/GitHub.pm
@@ -67,6 +67,15 @@ name.
 
 =back
 
+=head2 tags_only
+
+Boolean value for those repositories that do not upgrade their tags to releases.
+There are two different endpoints. One for
+L<releases|https://developer.github.com/v3/repos/releases/#list-releases-for-a-repository>
+and one for simple L<tags|https://developer.github.com/v3/repos/#list-tags>. The
+default is to interrogate the former for downloads. Passing a true value for
+L</"tags_only"> interrogates the latter for downloads.
+
 =head2 version
 
 Regular expression that can be used to extract a version from a GitHub tag.  The
@@ -101,6 +110,7 @@ has github_repo => sub { croak("github_repo is required") };
 has include_assets => 0;
 has version => qr/^v?(.*)$/;
 has prefer => 0;
+has tags_only => 0;
 
 sub init
 {
@@ -111,7 +121,8 @@ sub init
     croak("Don't set set a start_url with the Download::GitHub plugin");
   }
 
-  $meta->prop->{start_url} ||= "https://api.github.com/repos/@{[ $self->github_user ]}/@{[ $self->github_repo ]}/releases";
+  my $endpoint = $self->tags_only ? 'tags' : 'releases' ;
+  $meta->prop->{start_url} ||= "https://api.github.com/repos/@{[ $self->github_user ]}/@{[ $self->github_repo ]}/$endpoint";
 
   $meta->apply_plugin('Download',
     prefer  => $self->prefer,
@@ -126,7 +137,7 @@ sub init
       my $orig = shift;
       my($build, $url) = @_;
       my $res = $orig->($build, $url);
-      if($res->{type} eq 'file' && $res->{filename} eq 'releases')
+      if($res->{type} eq 'file' && $res->{filename} =~ qr{^(?:releases|tags)$})
       {
         my $rel;
         if($res->{content})
@@ -141,14 +152,16 @@ sub init
         {
           croak("malformed response object: no content or path");
         }
+        my $version_key = $res->{filename} eq 'releases' ? 'tag_name' : 'name';
+
         return {
           type => 'list',
           list => [
             map {
               my $release = $_;
-              my($version) = $release->{tag_name} =~ $self->version;
+              my($version) = $release->{$version_key} =~ $self->version;
               my @results = ({
-                filename => $release->{tag_name},
+                filename => $release->{$version_key},
                 url      => $release->{tarball_url},
                 defined $version ? (version  => $version) : (),
               });


### PR DESCRIPTION
Some repositories do not upgrade their tags to releases so even though the UI shows them as releases they are not included in the `releases` endpoint and currently unavailable using this plugin.

Add a `tags_only` property to allow queries against `https://api.github.com/repos/user/repo/tags` as well as the default `https://api.github.com/repos/user/repo/releases`